### PR TITLE
Binomial regression in nightly; fixing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,16 @@ addons:
     packages:
       - libopenblas-dev
       - gfortran
-matrix:
-  allow_failures:
-    - rust: nightly
+# matrix:
+  # allow_failures:
+    # - rust: nightly
 # add a job to test the nightly features on the nightly build
 jobs:
   include:
+    - rust: stable
+    - rust: beta
     - rust: nightly
+      allow_failures: true
       script:
         - cargo +nightly build --verbose --features nightly
         - cargo +nightly test --verbose --features nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,14 @@ addons:
     packages:
       - libopenblas-dev
       - gfortran
-# matrix:
-  # allow_failures:
-    # - rust: nightly
 # add a job to test the nightly features on the nightly build
 jobs:
-  include:
-    - rust: stable
-    - rust: beta
+  allow_failures:
     - rust: nightly
-      allow_failures: true
+  include:
+    # - rust: stable
+    # - rust: beta
+    - rust: nightly
       script:
         - cargo +nightly build --verbose --features nightly
         - cargo +nightly test --verbose --features nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ addons:
     packages:
       - libopenblas-dev
       - gfortran
+script:
+  nightly:
+    - cargo +nightly build --verbose --features nightly
+    - cargo +nightly test --verbose --features nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ rust:
   - stable
   - beta
   - nightly
-# These next two lines are mimicking rust-ndarray's config
-sudo: required
-dist: trusty
-# before_install:
-#   - sudo apt-get -q update
-#   - sudo apt-get -y install gfortran libblas-dev libopenblas-dev
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     packages:
       - libopenblas-dev
       - gfortran
-script:
-  nightly:
+nightly:
+  script:
     - cargo +nightly build --verbose --features nightly
     - cargo +nightly test --verbose --features nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,17 @@ rust:
   - stable
   - beta
   - nightly
-before_install:
-  - sudo apt-get -q update
-  - sudo apt-get -y install gfortran libblas-dev libopenblas-dev
+# These next two lines are mimicking rust-ndarray's config
+sudo: required
+dist: trusty
+# before_install:
+#   - sudo apt-get -q update
+#   - sudo apt-get -y install gfortran libblas-dev libopenblas-dev
 matrix:
   allow_failures:
     - rust: nightly
+addons:
+  apt:
+    packages:
+      - libopenblas-dev
+      - gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,11 @@ addons:
     packages:
       - libopenblas-dev
       - gfortran
-# add a job to test the nightly features on the nightly build
 jobs:
   allow_failures:
     - rust: nightly
   include:
-    # - rust: stable
-    # - rust: beta
+    # add a job to test the nightly features on the nightly build
     - rust: nightly
       script:
         - cargo +nightly build --verbose --features nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,18 @@ rust:
   - stable
   - beta
   - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
 addons:
   apt:
     packages:
       - libopenblas-dev
       - gfortran
-nightly:
-  script:
-    - cargo +nightly build --verbose --features nightly
-    - cargo +nightly test --verbose --features nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+# add a job to test the nightly features on the nightly build
+jobs:
+  include:
+    - rust: nightly
+      script:
+        - cargo +nightly build --verbose --features nightly
+        - cargo +nightly test --verbose --features nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ categories = ["mathematics", "science"]
 
 [features]
 openblas = ["ndarray-linalg/openblas"]
-# "openblas-src" implies "openblas"
-# This appears to have changed! Now there is no such feature in ndarray-linalg,
-# only openblas-static.
 openblas-src = ["ndarray-linalg/openblas-src"]
+# These last two are implied by openblas-static
+openblas-static = ["ndarray-linalg/openblas-static"]
 netlib = ["ndarray-linalg/netlib"]
 intel-mkl = ["ndarray-linalg/intel-mkl"]
 
@@ -25,18 +24,26 @@ intel-mkl = ["ndarray-linalg/intel-mkl"]
 # TODO: is rayon really needed? it should probably be a library feature
 # ndarray = { version = "0.13", features = ["blas", "rayon"]}
 ndarray = { version = "0.13", features = ["blas", "approx"] }
-ndarray-linalg = { version = "0.12" }
+# ndarray-linalg = { version = "0.12" }
+# The version with the latest openblas-src and blas-src versions doesn't have a crate yet.
+ndarray-linalg = { git = "https://github.com/rust-ndarray/ndarray-linalg" }
 num-traits = "0.2"
 thiserror = "1.0"
 itertools = "0.9"
 
 [dev-dependencies]
 # pick a backend to run tests
-blas-src = { version = "0.4", default-features = false, features = ["openblas"] }
-ndarray-linalg = { version = "0.12", default-features = false, features = ["openblas-src"]}
+# blas-src = { version = "0.4", default-features = false, features = ["openblas"] }
+blas-src = { version = "0.6", default-features = false, features = ["openblas"] }
+# ndarray-linalg = { version = "0.12", default-features = false, features = ["openblas-src"]}
+# ndarray-linalg = { version = "0.12", default-features = false, features = ["openblas-static"]}
+# the updates to blas versions have not been released in ndarray-linalg yet.
+ndarray-linalg = { git = "https://github.com/rust-ndarray/ndarray-linalg", branch = "master", default-features = false, features = ["openblas-static"] }
 anyhow = "1.0"
 approx = "0.3"
 # including openblas-src causes linking errors with LAPACKE?
 # Include it as a feature to ndarray-linalg instead.
 # https://github.com/blas-lapack-rs/openblas-src/issues/30
 # openblas-src = { version = "0.7.0", default-features = false, features = ["cblas", "lapacke", "system"] }
+# This appears to work but isn't necessary:
+# openblas-src = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ndarray-glm"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Felix Clark <mfclark3690@gmail.com>"]
 description = "Performs regression for general linear models on data stored in arrays using IRLS."
 edition = "2018"
 repository = "https://github.com/felix-clark/ndarray-glm"
 readme = "README.md"
 license = "MIT"
-keywords = ["statistics", "glm", "irls"]
+keywords = ["statistics", "glm", "regression", "irls"]
 categories = ["mathematics", "science"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -23,7 +23,6 @@ intel-mkl = ["ndarray-linalg/intel-mkl"]
 # TODO: is rayon really needed? it should probably be a library feature
 # ndarray = { version = "0.13", features = ["blas", "rayon"]}
 ndarray = { version = "0.13", features = ["blas", "approx"] }
-# perhaps the "openblas-src" feature should be reserved for a final crate?
 ndarray-linalg = { version = "0.12" }
 num-traits = "0.2"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,15 @@ license = "MIT"
 keywords = ["statistics", "glm", "regression", "irls"]
 categories = ["mathematics", "science"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[badges]
+maintenance = { status = "experimental" }
+travis-ci = { repository = "felix-clark/ndarray-glm" }
 
 [features]
 # enable all nightly features
 nightly = ["binomial"]
 
+# Feature flags to pass to ndarray-linalg
 openblas = ["ndarray-linalg/openblas"]
 openblas-src = ["ndarray-linalg/openblas-src"]
 # These last two are implied by openblas-static
@@ -23,7 +26,8 @@ openblas-static = ["ndarray-linalg/openblas-static"]
 netlib = ["ndarray-linalg/netlib"]
 intel-mkl = ["ndarray-linalg/intel-mkl"]
 
-# simply flag whether to use binomial response, which uses const_generics
+# flag to compile binomial regression, which uses const_generics only available
+# in nightly rust.
 binomial = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ categories = ["mathematics", "science"]
 [features]
 openblas = ["ndarray-linalg/openblas"]
 # "openblas-src" implies "openblas"
+# This appears to have changed! Now there is no such feature in ndarray-linalg,
+# only openblas-static.
 openblas-src = ["ndarray-linalg/openblas-src"]
 netlib = ["ndarray-linalg/netlib"]
 intel-mkl = ["ndarray-linalg/intel-mkl"]
@@ -26,7 +28,7 @@ ndarray = { version = "0.13", features = ["blas", "approx"] }
 ndarray-linalg = { version = "0.12" }
 num-traits = "0.2"
 thiserror = "1.0"
-itertools = "0.8"
+itertools = "0.9"
 
 [dev-dependencies]
 # pick a backend to run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,18 @@ categories = ["mathematics", "science"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+# enable all nightly features
+nightly = ["binomial"]
+
 openblas = ["ndarray-linalg/openblas"]
 openblas-src = ["ndarray-linalg/openblas-src"]
 # These last two are implied by openblas-static
 openblas-static = ["ndarray-linalg/openblas-static"]
 netlib = ["ndarray-linalg/netlib"]
 intel-mkl = ["ndarray-linalg/intel-mkl"]
+
+# simply flag whether to use binomial response, which uses const_generics
+binomial = []
 
 [dependencies]
 # TODO: is rayon really needed? it should probably be a library feature

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ To use the OpenBLAS backend, install also `libopenblas-dev` and use this crate w
 To use in your crate, add the following to the `Cargo.toml`:
 
 ```
-ndarray-glm = { version = "0.0.3", features = ["openblas-src"] }
+ndarray = { version = "0.13", features = ["blas"]}
+blas-src = { version = "0.6", default-features = false, features = ["openblas"] }
+ndarray-glm = { version = "0.0.3", features = ["openblas-static"] }
 ```
 
 An example for linear regression is shown below.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ regression it must be an unsigned integer.
 - [X] Generic over floating point type
 - [ ] Other exponential family distributions
   - [X] Poisson
-  - [ ] Binomial
+  - [X] Binomial (nightly only)
   - [ ] Exponential
   - [ ] Gamma (which effectively reduces to exponential with an arbitrary
         dispersion parameter)
@@ -83,18 +83,20 @@ regression it must be an unsigned integer.
   - [ ] Allow for off-diagonal correlations between points
   - [ ] Fix likelihood functions for weighted and/or correlated case
   - [ ] Re-visit the tolerance conditions for termination in these instances.
-- [ ] Non-canonical link functions
+- [-] Non-canonical link functions
 - [ ] Goodness-of-fit tests
-  - [ ] Log-likelihood difference from saturated model
+  - [ ] Log-likelihood difference from saturated model (deviance analysis)
   - [ ] Aikaike and Bayesian information criteria
   - [ ] generalized R^2?
 
 ### TODO
 
 - [ ] Generalize GLM interface to allow multi-parameter fits like a gamma
-      distribution.
+      distribution. This would demand other sufficient statistics besides y
+      (e.g. y^2 for Gaussian w/ variance, log(y) for gamma).
 - [ ] Exact Z-scores by re-minimizing after fixing each parameter to zero (?)
 - [ ] Calculate/estimate dispersion parameter from the data
+- [ ] More rigorous convergence tests and options for termination
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ iteratively reweighted least squares, using the `ndarray-linalg` module.
 
 ## Status
 
-This package is in early alpha and the interface is likely to undergo many changes.
+This package is in early alpha and the interface is likely to undergo many
+changes. Functionality may change from one release to the next.
+
+The regression algorithm uses iteratively re-weighted least squares (IRLS) with
+a step-halving procedure applied when the next iteration of guesses does not
+increase the likelihood.
 
 ## Prerequisites
+
 fortran and BLAS must be installed:
 ```
 sudo apt update && sudo apt install gfortran libblas-dev
@@ -20,6 +26,14 @@ sudo apt update && sudo apt install gfortran libblas-dev
 To use the OpenBLAS backend, install also `libopenblas-dev` and use this crate with the "openblas-src" feature.
 
 ## Example
+
+To use in your crate, add the following to the `Cargo.toml`:
+
+```
+ndarray-glm = { version = "0.0.3", features = ["openblas-src"] }
+```
+
+An example for linear regression is shown below.
 
 ``` rust
 use ndarray::array;
@@ -31,13 +45,17 @@ let data_x = array![[0.1, 0.2], [-0.4, 0.1], [0.2, 0.4]];
 // The design matrix can optionally be standardized, where the mean of each independent
 // variable is subtracted and each is then divided by the standard deviation of that variable.
 let data_x = standardize(data_x);
-// The model is general over floating point type.
-// If the second argument is left "_", it will be inferred if possible.
+// The model is generic over floating point type for the independent data variables.
+// If the second argument is blank (`_`), it will be inferred if possible.
 // L2 regularization can be applied with l2_reg().
 let model = ModelBuilder::<Linear, f32>::new(&data_y, &data_x).l2_reg(1e-5).build()?;
 let fit = model.fit()?;
+// Currently the result is a simple array of the MLE estimators, including the intercept term.
 println!("Fit result: {}", fit.result);
 ```
+
+For logistic regression, the `y` array data must be boolean, and for Poisson
+regression it must be an unsigned integer.
 
 ## Features
 
@@ -49,18 +67,20 @@ println!("Fit result: {}", fit.result);
 - [X] L2 (ridge) Regularization
 - [ ] L1 (lasso) Regularization
 - [X] Generic over floating point type
-- [X] Poisson
-- [ ] Exponential
-- [ ] Gamma (which effectively reduces to exponential with an arbitrary
-      dispersion parameter)
-- [ ] Inverse Gaussian
 - [ ] Other exponential family distributions
-- [ ] Option for data standardization/normalization
-- [ ] Weighted regressions
+  - [X] Poisson
+  - [ ] Binomial
+  - [ ] Exponential
+  - [ ] Gamma (which effectively reduces to exponential with an arbitrary
+        dispersion parameter)
+  - [ ] Inverse Gaussian
+  - [ ] ...
+- [X] Option for data standardization/normalization
+- [ ] Weighted and correlated regressions
   - [ ] Weight the covariance matrix with point-by-point error bars
   - [ ] Allow for off-diagonal correlations between points
-  - [ ] Fix likelihood functions
-  - [ ] Check the tolerance conditions for termination
+  - [ ] Fix likelihood functions for weighted and/or correlated case
+  - [ ] Re-visit the tolerance conditions for termination in these instances.
 - [ ] Non-canonical link functions
 - [ ] Goodness-of-fit tests
   - [ ] Log-likelihood difference from saturated model
@@ -72,16 +92,10 @@ println!("Fit result: {}", fit.result);
 - [ ] Generalize GLM interface to allow multi-parameter fits like a gamma
       distribution.
 - [ ] Exact Z-scores by re-minimizing after fixing each parameter to zero (?)
-- [ ] Unit tests for correct convergence with linear offsets
 - [ ] Calculate/estimate dispersion parameter from the data
 
+## Reference
 
-## References
-
-* [Author's notes](https://felix-clark.github.io/glm-math)
-* https://www.stat.cmu.edu/~ryantibs/advmethods/notes/glm.pdf
-* https://bwlewis.github.io/GLM/
-* https://statmath.wu.ac.at/courses/heather_turner/glmCourse_001.pdf
-* [Maalouf, M., & Siddiqi, M. (2014). Weighted logistic regression for large-scale imbalanced and rare events data. Knowledge-Based Systems, 59, 142–148.](https://doi.org/10.1016/j.knosys.2014.01.012)
-* [Disperson parameter lecture](http://people.stat.sfu.ca/~raltman/stat402/402L25.pdf)
-* [Convergence problems in GLMs](https://journal.r-project.org/archive/2011-2/RJournal_2011-2_Marschner.pdf)
+The author's [notes on generalized linear
+models](https://felix-clark.github.io/glm-math) summarize many of the relevant
+concepts and provide some additional references.

--- a/src/binomial.rs
+++ b/src/binomial.rs
@@ -1,0 +1,35 @@
+//! Regression with a binomial response function. The N parameter must be known ahead of time.
+use crate::{glm::Glm, model::Model};
+use ndarray::Array1;
+use ndarray_linalg::Lapack;
+use num_traits::{Float, ToPrimitive, Unsigned};
+
+/// Binomial regression with a fixed N.
+pub struct Binomial<const N: u32> {
+    _n: std::marker::PhantomData<u32>,
+    // N: usize,
+}
+
+impl<U, F, const N: u32> Glm<F> for Binomial<N>
+where
+    U: Unsigned + ToPrimitive,
+    F: Float + Lapack,
+{
+    type Domain = U;
+
+    fn y_float(y: Self::Domain) -> F {
+        F::from(y).unwrap()
+    }
+
+    fn link(y: F) -> F {
+        Float::ln(y / (F::from(N).unwrap() - y))
+    }
+
+    fn mean(lin_pred: F) -> F {
+        F::from(N).unwrap() * lin_pred
+    }
+
+    fn quasi_log_likelihood(data: &Model<Self, F>, regressors: &Array1<F>) -> F {
+        todo!("implement binomial likelihood");
+    }
+}

--- a/src/binomial.rs
+++ b/src/binomial.rs
@@ -1,21 +1,23 @@
 //! Regression with a binomial response function. The N parameter must be known ahead of time.
+//! This submodule uses const_generics, available only in nightly rust, and must
+//! be activated with the "binomial" feature option.
 use crate::{glm::Glm, model::Model};
+// use cauchy::Scalar;
 use ndarray::Array1;
 use ndarray_linalg::Lapack;
-use num_traits::{Float, ToPrimitive, Unsigned};
+use num_traits::Float;
+
+/// Use a fixed type of u16 for the domain of the binomial distribution.
+type BinDom = u16;
 
 /// Binomial regression with a fixed N.
-pub struct Binomial<const N: u32> {
-    _n: std::marker::PhantomData<u32>,
-    // N: usize,
-}
+pub struct Binomial<const N: BinDom>;
 
-impl<U, F, const N: u32> Glm<F> for Binomial<N>
+impl<F, const N: BinDom> Glm<F> for Binomial<N>
 where
-    U: Unsigned + ToPrimitive,
     F: Float + Lapack,
 {
-    type Domain = U;
+    type Domain = BinDom;
 
     fn y_float(y: Self::Domain) -> F {
         F::from(y).unwrap()
@@ -29,7 +31,41 @@ where
         F::from(N).unwrap() * lin_pred
     }
 
+    fn variance(mean: F) -> F {
+        let n_float: F = F::from(N).unwrap();
+        mean * (n_float - mean) / n_float
+    }
+
+    /// The binomial likelihood includes a BetaLn() term of N and y, which can
+    /// be skipped for parameter minimization.
     fn quasi_log_likelihood(data: &Model<Self, F>, regressors: &Array1<F>) -> F {
-        todo!("implement binomial likelihood");
+        let lin_pred: Array1<F> = data.linear_predictor(&regressors);
+        // in the canonical version, the natural parameter is logit(p)
+        let log_like_sum = (&data.y * &lin_pred).sum()
+            - F::from(N).unwrap() * lin_pred.mapv(Float::exp).mapv(F::ln_1p).sum();
+        log_like_sum + data.l2_like_term(regressors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Binomial;
+    use crate::{error::RegressionResult, model::ModelBuilder};
+    use approx::assert_abs_diff_eq;
+    use ndarray::array;
+
+    #[test]
+    fn bin_reg() -> RegressionResult<()> {
+        const N: u16 = 12;
+        let ln2 = f64::ln(2.);
+        let beta = array![0., 1.];
+        let data_x = array![[0.], [0.], [ln2], [ln2], [ln2]];
+        let data_y = array![5, 7, 9, 6, 9];
+        let model = ModelBuilder::<Binomial<N>, _>::new(&data_y, &data_x).build()?;
+        let fit = model.fit()?;
+        dbg!(&fit.result);
+        dbg!(&fit.n_iter);
+        assert_abs_diff_eq!(beta, fit.result, epsilon = 32.0 * std::f64::EPSILON);
+        Ok(())
     }
 }

--- a/src/binomial.rs
+++ b/src/binomial.rs
@@ -28,7 +28,7 @@ where
     }
 
     fn mean(lin_pred: F) -> F {
-        F::from(N).unwrap() * lin_pred
+        F::from(N).unwrap() / (F::one() + (-lin_pred).exp())
     }
 
     fn variance(mean: F) -> F {
@@ -60,12 +60,13 @@ mod tests {
         let ln2 = f64::ln(2.);
         let beta = array![0., 1.];
         let data_x = array![[0.], [0.], [ln2], [ln2], [ln2]];
+        // the first two data points should average to 6 and the last 3 should average to 8.
         let data_y = array![5, 7, 9, 6, 9];
         let model = ModelBuilder::<Binomial<N>, _>::new(&data_y, &data_x).build()?;
         let fit = model.fit()?;
         dbg!(&fit.result);
         dbg!(&fit.n_iter);
-        assert_abs_diff_eq!(beta, fit.result, epsilon = 32.0 * std::f64::EPSILON);
+        assert_abs_diff_eq!(beta, fit.result, epsilon = 0.05 * std::f32::EPSILON as f64);
         Ok(())
     }
 }

--- a/src/glm.rs
+++ b/src/glm.rs
@@ -216,7 +216,7 @@ where
         // Ideally we could only check the step difference but that might not be
         // as stable. Some parameters might be at different scales.
         let mut like = M::quasi_log_likelihood(&self.data, &next_guess);
-        // This should be positive for an improvement
+        // This should be positive for an improved guess
         let mut rel = (like - self.last_like) / (F::epsilon() + like.abs());
         // Terminate if the difference is close to zero
         if rel.abs() <= self.tolerance {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@
 // but maybe it should only go into final library
 // extern crate openblas_src;
 
-// pub mod data;
+// #![feature(const_generics)]
+// pub mod binomial;
+
 pub mod error;
 mod fit;
 mod glm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,11 @@
 // but maybe it should only go into final library
 // extern crate openblas_src;
 
-// #![feature(const_generics)]
-// pub mod binomial;
-
+// enable const_generics if the binomial feature is used.
+#![cfg_attr(feature = "binomial", feature(const_generics))]
+// opt-in for binomial regression as it utilizes unstable features.
+#[cfg(feature = "binomial")]
+pub mod binomial;
 pub mod error;
 mod fit;
 mod glm;
@@ -20,7 +22,6 @@ mod utility;
 
 #[cfg(test)]
 mod tests {
-    // use super::*;
     use crate::{
         error::RegressionResult, linear::Linear, logistic::Logistic, model::ModelBuilder,
         poisson::Poisson,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod tests {
         let model = ModelBuilder::<Logistic, _>::new(&data_y, &data_x).build()?;
         let fit = model.fit()?;
         dbg!(fit.n_iter);
-        assert_abs_diff_eq!(beta, fit.result, epsilon = std::f32::EPSILON as f64);
+        assert_abs_diff_eq!(beta, fit.result, epsilon = 0.05 * std::f32::EPSILON as f64);
         // test the significance function
         let significance = fit.z_scores(&model);
         dbg!(significance);

--- a/src/linear.rs
+++ b/src/linear.rs
@@ -5,11 +5,15 @@ use ndarray::Array1;
 use ndarray_linalg::Lapack;
 use num_traits::Float;
 
-pub struct Linear;
+/// Linear regression with constant variance.
+pub struct Linear<Link = Id> {
+    _link: std::marker::PhantomData<Link>,
+}
 
-impl<F> Glm<F> for Linear
+impl<F, L> Glm<F> for Linear<L>
 where
     F: Float + Lapack,
+    L: LinLink,
 {
     type Domain = F;
 
@@ -19,15 +23,15 @@ where
 
     // the link function, identity
     fn link(y: F) -> F {
-        y
+        L::func(y)
     }
 
     // inverse link function, identity
     fn mean(lin_pred: F) -> F {
-        lin_pred
+        L::inv_func(lin_pred)
     }
 
-    // variance is not a function of the mean
+    // variance is not a function of the mean in OLS regression.
     fn variance(_mean: F) -> F {
         F::one()
     }
@@ -37,8 +41,34 @@ where
     // It also misses a factor of 0.5 in the squares.
     fn quasi_log_likelihood(data: &Model<Self, F>, regressors: &Array1<F>) -> F {
         let lin_pred = &data.linear_predictor(&regressors);
+        // TODO: transform the linear predictors in the event of a non-identity link function
         let squares: Array1<F> = (&data.y - lin_pred).map(|&d| d * d);
         let l2_term = data.l2_like_term(regressors);
         -squares.sum() + l2_term
+    }
+}
+
+/// A trait describing link functions for linear regression.
+pub trait LinLink {
+    fn func<F: Float>(y: F) -> F;
+    fn inv_func<F: Float>(lin_pred: F) -> F;
+    // TODO: parameter transform function, its derivatives, ..., propagate this info to the likelihood
+    // the transformation function that takes the linear predictor to the
+    // canonical parameter. Should always be identify for canonical link
+    // functions.
+    fn canonical<F: Float>(lin_pred: Array1<F>) -> Array1<F>;
+}
+
+/// The identity link function, which is canonical for linear regression.
+pub struct Id;
+impl LinLink for Id {
+    fn func<F>(y: F) -> F {
+        y
+    }
+    fn inv_func<F>(lin_pred: F) -> F {
+        lin_pred
+    }
+    fn canonical<F>(lin_pred: Array1<F>) -> Array1<F> {
+        lin_pred
     }
 }

--- a/src/poisson.rs
+++ b/src/poisson.rs
@@ -10,12 +10,11 @@ use num_traits::{Float, ToPrimitive, Unsigned};
 use std::marker::PhantomData;
 
 /// Poisson regression over an unsigned integer type.
-/// TODO: Do we really need the unsigned type in the model specification?
 pub struct Poisson<D>
 where
     D: Unsigned,
 {
-    unsigned: PhantomData<D>,
+    _unsigned: PhantomData<D>,
 }
 
 impl<D, F> Glm<F> for Poisson<D>

--- a/src/poisson.rs
+++ b/src/poisson.rs
@@ -9,7 +9,8 @@ use ndarray_linalg::Lapack;
 use num_traits::{Float, ToPrimitive, Unsigned};
 use std::marker::PhantomData;
 
-/// trait-based implementation to work towards generalization
+/// Poisson regression over an unsigned integer type.
+/// TODO: Do we really need the unsigned type in the model specification?
 pub struct Poisson<D>
 where
     D: Unsigned,

--- a/tests/linear_offset.rs
+++ b/tests/linear_offset.rs
@@ -1,0 +1,33 @@
+//! testing closure with a linear offset
+
+use anyhow::Result;
+use approx::assert_abs_diff_eq;
+use ndarray::{array, Array1, Array2};
+use ndarray_glm::{linear::Linear, model::ModelBuilder};
+
+#[test]
+/// Check that the result is the same in linear regression when subtracting
+/// offsets from the y values as it is when adding linear offsets to the model.
+fn test_intercept() -> Result<()> {
+    let y_data: Array1<f64> = array![0.6, 0.3, 0.5, 0.1];
+    let offsets: Array1<f64> = array![0.1, -0.1, 0.2, 0.0];
+    let x_data: Array2<f64> = array![[1.2, 0.7], [2.1, 0.8], [1.5, 0.6], [1.6, 0.3]];
+
+    let lin_model = ModelBuilder::<Linear, _>::new(&y_data, &x_data)
+        .linear_offset(offsets.clone())
+        .build()?;
+    let lin_fit = lin_model.fit()?;
+    let y_offset = y_data - offsets;
+    let lin_model_off = ModelBuilder::<Linear, _>::new(&y_offset, &x_data).build()?;
+    let lin_fit_off = lin_model_off.fit()?;
+    dbg!(&lin_fit.result);
+    dbg!(&lin_fit_off.result);
+    // Ensure that the two methods give consistent results
+    assert_abs_diff_eq!(
+        lin_fit.result,
+        lin_fit_off.result,
+        epsilon = 16.0 * std::f64::EPSILON
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Binomial regression uses const_generics and is hidden behind the "binomial" feature flag. Updated the openblas versions using the master tag of `ndarray-linalg` which allowed the CI to be fixed. Started an example on how to generalize link functions (in basic linear regression).